### PR TITLE
Attempt at making TreeNode more flexible

### DIFF
--- a/src/DrDotnet.Profilers/utils/tree.rs
+++ b/src/DrDotnet.Profilers/utils/tree.rs
@@ -1,36 +1,28 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use core::fmt::Display;
+use std::ops::AddAssign;
 
 #[derive(Debug, Clone)]
-struct TreeNode<T> {
-    value: T,
-    exclusive: usize,
-    inclusive: usize,
-    depth: usize, // Do we need this?
-    children: Vec<TreeNode<T>>,
+struct TreeNode<K, D> {
+    pub key: K,
+    pub value: Option<D>,
+    pub children: Vec<TreeNode<K, D>>,
 }
 
-impl<T> TreeNode<T>
-    where T: PartialEq + Copy
+impl<K, D> TreeNode<K, D>
+    where K: PartialEq + Copy, D: Clone
 {
-    fn new(value: T) -> Self {
+    pub fn new(key: K, value: Option<D>) -> Self {
         TreeNode {
+            key,
             value,
             children: Vec::new(),
-            exclusive: 0,
-            inclusive: 0,
-            depth: 0,
         }
     }
 
-    fn add_child(&mut self, child: TreeNode<T>) {
-        self.children.push(child);
-    }
-
     // Sort children recursively based on the given closure
-    fn sort_by<F>(&mut self, compare: &F)
-        where F: Fn(&TreeNode<T>, &TreeNode<T>) -> Ordering,
+    pub fn sort_by<F>(&mut self, compare: &F)
+        where F: Fn(&TreeNode<K, D>, &TreeNode<K, D>) -> Ordering,
     {
         self.children.sort_by(compare);
         for child in &mut self.children {
@@ -38,25 +30,21 @@ impl<T> TreeNode<T>
         }
     }
 
-    fn build_from_sequences(sequences: &HashMap<Vec<T>, usize>, root_value: T) -> TreeNode<T> {
-        let mut root = TreeNode::new(root_value);
+    pub fn build_from_sequences(sequences: &HashMap<Vec<K>, D>, root_key: K) -> TreeNode<K, D> {
+        let mut root = TreeNode::new(root_key, None);
         for (sequence, value) in sequences {
-            root.inclusive += value;
             let mut current = &mut root;
             let mut depth: usize = 1;
             let l = sequence.len();
             for y in sequence {
-                let mut child = if let Some(i) = current.children.iter().position(|child| child.value.eq(&y)) {
+                let mut child = if let Some(i) = current.children.iter().position(|child| child.key.eq(&y)) {
                     &mut current.children[i]
                 } else {
-                    let mut new_child: TreeNode<T> = TreeNode::new(*y);
-                    new_child.exclusive = if depth == l { *value } else { 0 };
+                    let mut new_child: TreeNode<K, D> = TreeNode::new(*y, if depth == l { Some(value.clone()) } else { None });
                     current.children.push(new_child);
                     let len = current.children.len();
                     &mut current.children[len - 1]
                 };
-                child.depth = depth;
-                child.inclusive += value;
                 current = child;
                 depth+=1;
             }
@@ -65,12 +53,11 @@ impl<T> TreeNode<T>
     }
 }
 
-// Implement the PartialEq trait for TreeNode
-impl<T> PartialEq for TreeNode<T>
-    where T: Eq
+impl<K, D> PartialEq for TreeNode<K, D>
+    where K: Eq
 {
     fn eq(&self, other: &Self) -> bool {
-        if self.value != other.value || self.children.len() != other.children.len() {
+        if self.key != other.key || self.children.len() != other.children.len() {
             return false;
         }
         for (child1, child2) in self.children.iter().zip(other.children.iter()) {
@@ -82,44 +69,44 @@ impl<T> PartialEq for TreeNode<T>
     }
 }
 
-// Implement the Eq trait for TreeNode
-impl<T> Eq for TreeNode<T>
-    where T: Eq {}
+impl<K, D> Eq for TreeNode<K, D>
+    where K: Eq {}
+
+impl<K, D> TreeNode<K, D>
+    where D: AddAssign + Default + Clone
+{
+    // Compute recursively and return the inclusive value of a given TreeNode
+    pub fn get_inclusive_value(&self) -> D
+    {
+        let mut inclusive_data = if let Some(self_data) = &self.value {
+            self_data.clone()
+        } else {
+            D::default()
+        };
+        for child in self.children.iter() {
+            let child_inclusive_value = child.get_inclusive_value();
+            inclusive_data += child_inclusive_value;
+        }
+        inclusive_data
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn print<T>(tree: &TreeNode<T>, depth: usize)
-        where T: Display
+    fn print<T, D, F>(tree: &TreeNode<T, D>, depth: usize, format: &F)
+        where F: Fn(&TreeNode<T, D>) -> String
     {
         let tabs = " ".repeat(depth);
-        println!("{}- {} (inc:{}, exc:{})", tabs, tree.value, tree.inclusive, tree.exclusive);
+        println!("{}- {}", tabs, format(tree));
 
         for child in &tree.children {
-            print(child, depth + 1);
+            print(child, depth + 1, format);
         }
     }
 
     // Run tests with 'cargo test -- --nocapture' to get output in console
-    #[test]
-    fn test_print() {
-        // Sequences of u32
-        let sequences: HashMap<Vec<u32>, usize> = HashMap::from([
-            (vec![1, 2, 3], 1),
-            (vec![2, 2, 3], 2),
-            (vec![1, 2], 3),
-            (vec![1, 2, 4], 5),
-            (vec![1, 3, 5], 6),
-            (vec![2, 3, 2, 1, 4], 7),
-            (vec![1, 3, 5, 1], 8),
-        ]);
-
-        let tree = TreeNode::build_from_sequences(&sequences, 0);
-
-        print(&tree, 0);
-    }
-
     #[test]
     fn test_tree() {
         // Sequences of u32
@@ -135,29 +122,74 @@ mod tests {
 
         // Expected sequences in a tree, sorted by descending inclusive value
         let expected =
-        TreeNode { value: 0, exclusive: 0, inclusive: 32, depth: 0, children: vec![
-            TreeNode { value: 1, exclusive: 0, inclusive: 23, depth: 1, children: vec![
-                TreeNode { value: 3, exclusive: 0, inclusive: 14, depth: 2, children: vec![
-                    TreeNode { value: 5, exclusive: 0, inclusive: 14, depth: 3, children: vec![
-                        TreeNode { value: 1, exclusive: 8, inclusive: 8, depth: 4, children: vec![] }] }] },
-                TreeNode { value: 2, exclusive: 3, inclusive: 9, depth: 2, children: vec![
-                    TreeNode { value: 4, exclusive: 5, inclusive: 5, depth: 3, children: vec![] },
-                    TreeNode { value: 3, exclusive: 1, inclusive: 1, depth: 3, children: vec![] }] }] },
-            TreeNode { value: 2, exclusive: 0, inclusive: 9, depth: 1, children: vec![
-                TreeNode { value: 3, exclusive: 0, inclusive: 7, depth: 2, children: vec![
-                    TreeNode { value: 2, exclusive: 0, inclusive: 7, depth: 3, children: vec![
-                        TreeNode { value: 1, exclusive: 0, inclusive: 7, depth: 4, children: vec![
-                            TreeNode { value: 4, exclusive: 7, inclusive: 7, depth: 5, children: vec![] }] }] }] },
-                TreeNode { value: 2, exclusive: 0, inclusive: 2, depth: 2, children: vec![
-                    TreeNode { value: 3, exclusive: 2, inclusive: 2, depth: 3, children: vec![] }] }] }] };
+        TreeNode { key: 0, value: None, children: vec![
+            TreeNode { key: 1, value: None, children: vec![
+                TreeNode { key: 3, value: None, children: vec![
+                    TreeNode { key: 5, value: Some(6), children: vec![
+                        TreeNode { key: 1, value: Some(8), children: vec![] }] }] },
+                TreeNode { key: 2, value: Some(3), children: vec![
+                    TreeNode { key: 4, value: Some(5), children: vec![] },
+                    TreeNode { key: 3, value: Some(1), children: vec![] }] }] },
+            TreeNode { key: 2, value: None, children: vec![
+                TreeNode { key: 3, value: None, children: vec![
+                    TreeNode { key: 2, value: None, children: vec![
+                        TreeNode { key: 1, value: None, children: vec![
+                            TreeNode { key: 4, value: Some(7), children: vec![] }] }] }] },
+                TreeNode { key: 2, value: None, children: vec![
+                    TreeNode { key: 3, value: Some(2), children: vec![] }] }] }] };
 
         let mut tree = TreeNode::build_from_sequences(&sequences, 0);
+
+        println!("Unsorted:");
+        print(&tree, 0, &|node: &TreeNode<u32, usize>| format!("{} [inc:{}, exc:{:?}]", node.key, node.get_inclusive_value(), node.value));
 
         assert_ne!(tree, expected);
 
         // Sorts by descending inclusive value
-        tree.sort_by(&|a, b| b.inclusive.cmp(&a.inclusive));
+        tree.sort_by(&|a, b| b.get_inclusive_value().cmp(&a.get_inclusive_value()));
+
+        println!("Sorted:");
+        print(&tree, 0, &|node: &TreeNode<u32, usize>| format!("{} [inc:{}, exc:{:?}]", node.key, node.get_inclusive_value(), node.value));
 
         assert_eq!(tree, expected);
+    }
+
+    #[test]
+    fn test_pstack() {
+
+        type FunctionID = u32;
+        type ThreadID = u32;
+    
+        // Required to wrap Vec<ThreadID> in order to implement AddAssign
+        #[derive(Clone, Default, Debug)]
+        pub struct Threads(Vec<ThreadID>);
+    
+        // Implement AddAssign for get_inclusive_value to be usable
+        impl AddAssign for Threads {
+            fn add_assign(&mut self, other: Self) {
+                self.0.extend(other.0);
+            }
+        }
+
+        let sequences: HashMap<Vec<FunctionID>, Threads> = HashMap::from([
+            (vec![1, 2, 3], Threads(vec![1001, 1002, 1003])),
+            (vec![2, 2, 3], Threads(vec![1004, 1005])),
+            (vec![1, 2], Threads(vec![1006])),
+            (vec![1, 2, 4], Threads(vec![1007, 1008, 1009])),
+            (vec![1, 3, 5], Threads(vec![1010])),
+            (vec![2, 3, 2, 1, 4], Threads(vec![1010, 1011, 1012, 1013])),
+            (vec![1, 3, 5, 1], Threads(vec![1014, 1015])),
+        ]);
+
+        let mut tree = TreeNode::build_from_sequences(&sequences, 0);
+
+        println!("Unsorted:");
+        print(&tree, 0, &|node| format!("{} [inc:{:?}, exc:{:?}]", node.key, node.get_inclusive_value(), node.value));
+
+        // Sorts by descending inclusive value
+        tree.sort_by(&|a, b| b.get_inclusive_value().0.len().cmp(&a.get_inclusive_value().0.len()));
+
+        println!("Sorted:");
+        print(&tree, 0, &|node| format!("{} [inc:{:?}, exc:{:?}]", node.key, node.get_inclusive_value(), node.value));
     }
 }


### PR DESCRIPTION
Here is an attempt at making it even more flexible, EG usable with thread IDs.

Main difference is that TreeNode no longer has inclusive / exclusive numeric fields. Instead it will store whatever object you need to store, like a group of thread IDs. Then you can use the optional `get_inclusive_value` function get an inclusive view of whatever data you have in there. It's a little less performant because it's not precomputed but it's no big hassle since this is computed after the report generation stage.

See this "test" I added:

```rust
type FunctionID = u32;
type ThreadID = u32;

// Required to wrap Vec<ThreadID> in order to implement AddAssign
#[derive(Clone, Default, Debug)]
pub struct Threads(Vec<ThreadID>);

// Implement AddAssign for get_inclusive_value to be usable
impl AddAssign for Threads {
    fn add_assign(&mut self, other: Self) {
        self.0.extend(other.0);
    }
}

let sequences: HashMap<Vec<FunctionID>, Threads> = HashMap::from([
    (vec![1, 2, 3], Threads(vec![1001, 1002, 1003])),
    (vec![2, 2, 3], Threads(vec![1004, 1005])),
    (vec![1, 2], Threads(vec![1006])),
    (vec![1, 2, 4], Threads(vec![1007, 1008, 1009])),
    (vec![1, 3, 5], Threads(vec![1010])),
    (vec![2, 3, 2, 1, 4], Threads(vec![1010, 1011, 1012, 1013])),
    (vec![1, 3, 5, 1], Threads(vec![1014, 1015])),
]);

let mut tree = TreeNode::build_from_sequences(&sequences, 0);

println!("Unsorted:");
print(&tree, 0, &|node| format!("{} [inc:{:?}, exc:{:?}]", node.key, node.get_inclusive_value(), node.value));

// Sorts by descending inclusive value
// Here we use get_inclusive_value() to aggregate threads by inclusive paths and then len() to compute to total count for the sorting to operate on
tree.sort_by(&|a, b| b.get_inclusive_value().0.len().cmp(&a.get_inclusive_value().0.len()));

println!("Sorted:");
print(&tree, 0, &|node| format!("{} [inc:{:?}, exc:{:?}]", node.key, node.get_inclusive_value(), node.value));
```

Here is the sorted output:
```rust
- 0 [inc:Threads([1006, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1014, 1015, 1010, 1011, 1012, 1013, 1004, 1005]), exc:None]
 - 1 [inc:Threads([1006, 1001, 1002, 1003, 1007, 1008, 1009, 1010, 1014, 1015]), exc:None]
  - 2 [inc:Threads([1006, 1001, 1002, 1003, 1007, 1008, 1009]), exc:Some(Threads([1006]))]
   - 3 [inc:Threads([1001, 1002, 1003]), exc:Some(Threads([1001, 1002, 1003]))]
   - 4 [inc:Threads([1007, 1008, 1009]), exc:Some(Threads([1007, 1008, 1009]))]
  - 3 [inc:Threads([1010, 1014, 1015]), exc:None]
   - 5 [inc:Threads([1010, 1014, 1015]), exc:Some(Threads([1010]))]
    - 1 [inc:Threads([1014, 1015]), exc:Some(Threads([1014, 1015]))]
 - 2 [inc:Threads([1010, 1011, 1012, 1013, 1004, 1005]), exc:None]
  - 3 [inc:Threads([1010, 1011, 1012, 1013]), exc:None]
   - 2 [inc:Threads([1010, 1011, 1012, 1013]), exc:None]
    - 1 [inc:Threads([1010, 1011, 1012, 1013]), exc:None]
     - 4 [inc:Threads([1010, 1011, 1012, 1013]), exc:Some(Threads([1010, 1011, 1012, 1013]))]
  - 2 [inc:Threads([1004, 1005]), exc:None]
   - 3 [inc:Threads([1004, 1005]), exc:Some(Threads([1004, 1005]))]
```