### PR TITLE
Revert caching to limit RAM usage in profiled app

### DIFF
--- a/src/DrDotnet.Profilers/profilers/gc_survivors_profiler.rs
+++ b/src/DrDotnet.Profilers/profilers/gc_survivors_profiler.rs
@@ -215,10 +215,10 @@ impl GCSurvivorsProfiler
         let mut compare = &|a:&TreeNode<usize, References>, b:&TreeNode<usize, References>| {
             if sort_by_size {
                 // Sorts by descending inclusive size
-                b.inclusive_value.0.values().sum::<usize>().cmp(&a.inclusive_value.0.values().sum::<usize>())
+                b.get_inclusive_value().0.values().sum::<usize>().cmp(&a.get_inclusive_value().0.values().sum::<usize>())
             } else {
                 // Sorts by descending inclusive count
-                b.inclusive_value.0.len().cmp(&a.inclusive_value.0.len())
+                b.get_inclusive_value().0.len().cmp(&a.get_inclusive_value().0.len())
             }
         };
 
@@ -251,10 +251,10 @@ impl GCSurvivorsProfiler
         //         print(child, depth + 1, format);
         //     }
         // }
-        // print(&tree, 0, &|node: &TreeNode<ClassID, References>| format!("{} [inc:{}, exc:{:?}]",  self.clr().get_class_name(node.key), node.inclusive_value, node.value));
+        // print(&tree, 0, &|node: &TreeNode<ClassID, References>| format!("{} [inc:{}, exc:{:?}]",  self.clr().get_class_name(node.key), node.get_inclusive_value(), node.value));
 
         let nb_classes = tree.children.len();
-        let nb_objects: usize = tree.children.iter().map(|x| x.inclusive_value.0.len()).sum();
+        let nb_objects: usize = tree.children.iter().map(|x| x.get_inclusive_value().0.len()).sum();
 
         let mut report = self.session_info.create_report("summary.html".to_owned());
 
@@ -272,7 +272,7 @@ impl GCSurvivorsProfiler
 
     fn print_html(&self, tree: &TreeNode<ClassID, References>, is_same_level: bool, report: &mut Report)
     {
-        let refs = &tree.inclusive_value;
+        let refs = &tree.get_inclusive_value();
         let nb_objects = refs.0.len();
         let class_name = self.clr().get_class_name(tree.key);
 
@@ -293,7 +293,7 @@ impl GCSurvivorsProfiler
             }
             
             let has_same_alignment = (child.children.is_empty() || child.children.len() == 1)
-                && nb_objects == child.inclusive_value.0.len();
+                && nb_objects == child.get_inclusive_value().0.len();
             
             if has_same_alignment && !is_same_level {
                 report.write(format!("\n<ul>\n"));

--- a/src/DrDotnet.Profilers/utils/tree.rs
+++ b/src/DrDotnet.Profilers/utils/tree.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
-use std::collections::HashMap;
-use std::collections::vec_deque::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::ops::AddAssign;
 use rayon::prelude::*;
 
@@ -9,18 +8,16 @@ pub struct TreeNode<K, V> {
     pub key: K,
     pub value: Option<V>,
     pub children: Vec<TreeNode<K, V>>,
-    pub inclusive_value: V
 }
 
 impl<K, V> TreeNode<K, V>
-    where K: PartialEq + Copy + Sync + Send, V: for<'a> AddAssign<&'a V> + Default + Clone + Sync + Send,
+    where K: PartialEq + Copy + Sync + Send, V: Clone + Sync + Send
 {
     pub fn new(key: K) -> Self {
         TreeNode {
             key,
             value: None,
             children: Vec::new(),
-            inclusive_value: V::default()
         }
     }
 
@@ -77,22 +74,7 @@ impl<K, V> TreeNode<K, V>
             }
             current.value = Some(value.clone());
         }
-        
-        root.calculate_all_inclusive_value();
-        
         return root;
-    }
-
-    fn calculate_all_inclusive_value(&mut self)
-    {
-        let mut queue = VecDeque::new();
-        queue.push_back(self);
-        while let Some(node) = queue.pop_front() {
-            node.inclusive_value = node.calculate_inclusive_value();
-            for child in &mut node.children {
-                queue.push_back(child);
-            }
-        }
     }
 }
 
@@ -128,7 +110,7 @@ impl<K, V> TreeNode<K, V>
     }
 
     // Compute recursively and return the inclusive value of a given TreeNode
-    pub fn calculate_inclusive_value(&self) -> V {
+    pub fn get_inclusive_value(&self) -> V {
         // Creating a single vector and passing it through get_inclusive_value_recursive
         // enables us to avoid cloning.
         let mut value = V::default();
@@ -169,45 +151,54 @@ mod tests {
 
         // Expected sequences in a tree, sorted by descending inclusive value
         let expected =
-        TreeNode { key: 0, value: None, inclusive_value: 28, children: vec![
-            TreeNode { key: 1, value: None, inclusive_value: 20, children: vec![
-                TreeNode { key: 3, value: None, inclusive_value: 12, children: vec![
-                    TreeNode { key: 5, value: Some(5), inclusive_value: 12, children: vec![
-                        TreeNode { key: 1, value: Some(7), inclusive_value: 7, children: vec![] }] }] },
-                TreeNode { key: 2, value: Some(3), inclusive_value: 8 , children: vec![
-                    TreeNode { key: 4, value: Some(4), inclusive_value: 4, children: vec![] },
-                    TreeNode { key: 3, value: Some(1), inclusive_value: 1, children: vec![] }]}] },
-            TreeNode { key: 2, value: None, inclusive_value: 8, children: vec![
-                TreeNode { key: 3, value: None, inclusive_value: 6, children: vec![
-                    TreeNode { key: 2, value: None, inclusive_value: 6, children: vec![
-                        TreeNode { key: 1, value: None, inclusive_value: 6, children: vec![
-                            TreeNode { key: 4, value: Some(6), inclusive_value: 6 , children: vec![] }] }] }] },
-                TreeNode { key: 2, value: None, inclusive_value: 2, children: vec![
-                    TreeNode { key: 3, value: Some(2), inclusive_value: 2, children: vec![] }] }] }] };
+        TreeNode { key: 0, value: None, children: vec![
+            TreeNode { key: 1, value: None, children: vec![
+                TreeNode { key: 3, value: None, children: vec![
+                    TreeNode { key: 5, value: Some(5), children: vec![
+                        TreeNode { key: 1, value: Some(7), children: vec![] }] }] },
+                TreeNode { key: 2, value: Some(3), children: vec![
+                    TreeNode { key: 4, value: Some(4), children: vec![] },
+                    TreeNode { key: 3, value: Some(1), children: vec![] }] }] },
+            TreeNode { key: 2, value: None, children: vec![
+                TreeNode { key: 3, value: None, children: vec![
+                    TreeNode { key: 2, value: None, children: vec![
+                        TreeNode { key: 1, value: None, children: vec![
+                            TreeNode { key: 4, value: Some(6), children: vec![] }] }] }] },
+                TreeNode { key: 2, value: None, children: vec![
+                    TreeNode { key: 3, value: Some(2), children: vec![] }] }] }] };
 
-        let tree = TreeNode::build_from_sequences(&sequences, 0);
+        let mut tree = TreeNode::build_from_sequences(&sequences, 0);
 
         println!("Unsorted:");
-        print(&tree, 0, &|node: &TreeNode<u32, usize>| format!("{} [inc:{}, exc:{:?}]", node.key, node.inclusive_value, node.value));
+        print(&tree, 0, &|node: &TreeNode<u32, usize>| format!("{} [inc:{}, exc:{:?}]", node.key, node.get_inclusive_value(), node.value));
         assert_ne!(tree, expected);
 
         // Sorts by descending inclusive value
         let mut tree_clone = tree.clone();
         assert_ne!(tree_clone, expected);
-        tree_clone.sort_by(&|a, b| b.inclusive_value.cmp(&a.inclusive_value));
+        let start = Instant::now();
+        tree_clone.sort_by(&|a, b| b.get_inclusive_value().cmp(&a.get_inclusive_value()));
+        let duration = start.elapsed();
+        println!("Recursive sort_by duration: {:?}", duration);
         assert_eq!(tree_clone, expected);
         
         let mut tree_clone = tree.clone();
         assert_ne!(tree_clone, expected);
-        tree_clone.sort_by_iterative(&|a, b| b.inclusive_value.cmp(&a.inclusive_value));
+        let start = Instant::now();
+        tree_clone.sort_by_iterative(&|a, b| b.get_inclusive_value().cmp(&a.get_inclusive_value()));
+        let duration = start.elapsed();
+        println!("Iterative sort_by duration: {:?}", duration);
         assert_eq!(tree_clone, expected);
 
         let mut tree_clone = tree.clone();
         assert_ne!(tree_clone, expected);
-        tree_clone.sort_by_multithreaded(&|a, b| b.inclusive_value.cmp(&a.inclusive_value));
+        let start = Instant::now();
+        tree_clone.sort_by_multithreaded(&|a, b| b.get_inclusive_value().cmp(&a.get_inclusive_value()));
+        let duration = start.elapsed();
+        println!("Multithreaded sort_by duration: {:?}", duration);
         assert_eq!(tree_clone, expected);
 
-        print(&tree_clone, 0, &|node: &TreeNode<u32, usize>| format!("{} [inc:{}, exc:{:?}]", node.key, node.inclusive_value, node.value));
+        print(&tree_clone, 0, &|node: &TreeNode<u32, usize>| format!("{} [inc:{}, exc:{:?}]", node.key, node.get_inclusive_value(), node.value));
     }
 
     #[test]
@@ -246,19 +237,19 @@ mod tests {
         let mut tree = TreeNode::build_from_sequences(&sequences, 0);
 
         println!("Unsorted:");
-        print(&tree, 0, &|node| format!("{} [inc:{:?}, exc:{:?}]", node.key, node.inclusive_value, node.value));
+        print(&tree, 0, &|node| format!("{} [inc:{:?}, exc:{:?}]", node.key, node.get_inclusive_value(), node.value));
 
         // Sorts by descending inclusive value
         let mut tree_sorted = tree.clone();
         let start = Instant::now();
-        tree_sorted.sort_by(&|a, b| b.inclusive_value.0.len().cmp(&a.inclusive_value.0.len()));
+        tree_sorted.sort_by(&|a, b| b.get_inclusive_value().0.len().cmp(&a.get_inclusive_value().0.len()));
         let duration = start.elapsed();
         println!("Recursive sort_by duration: {:?}", duration);
 
         let mut tree_clone = tree.clone();
         assert_ne!(tree_clone, tree_sorted);
         let start = Instant::now();
-        tree_clone.sort_by_iterative(&|a, b| b.inclusive_value.0.len().cmp(&a.inclusive_value.0.len()));
+        tree_clone.sort_by_iterative(&|a, b| b.get_inclusive_value().0.len().cmp(&a.get_inclusive_value().0.len()));
         let duration = start.elapsed();
         println!("Iterative sort_by duration: {:?}", duration);
         assert_eq!(tree_clone, tree_sorted);
@@ -266,12 +257,12 @@ mod tests {
         let mut tree_clone = tree.clone();
         assert_ne!(tree_clone, tree_sorted);
         let start = Instant::now();
-        tree_clone.sort_by_multithreaded(&|a, b| b.inclusive_value.0.len().cmp(&a.inclusive_value.0.len()));
+        tree_clone.sort_by_multithreaded(&|a, b| b.get_inclusive_value().0.len().cmp(&a.get_inclusive_value().0.len()));
         let duration = start.elapsed();
         println!("Multithreaded sort_by duration: {:?}", duration);
         assert_eq!(tree_clone, tree_sorted);
         
         println!("Sorted:");
-        print(&tree_sorted, 0, &|node| format!("{} [inc:{:?}, exc:{:?}]", node.key, node.inclusive_value, node.value));
+        print(&tree_sorted, 0, &|node| format!("{} [inc:{:?}, exc:{:?}]", node.key, node.get_inclusive_value(), node.value));
     }
 }


### PR DESCRIPTION
Caching `inclusive_value` in `TreeNode` significantly increases memory usage depending on the profiled app. My tests showed that GC Survivor more than doubled the memory usage of the profiled application. Without caching, memory usage still increases but not as much. I believe it’s important to minimize our memory footprint to prevent our app from being terminated due to memory pressure.
