### PR TITLE
Use crate to encoding/escaping special characters in HTML

### DIFF
--- a/src/DrDotnet.Profilers/Cargo.toml
+++ b/src/DrDotnet.Profilers/Cargo.toml
@@ -22,6 +22,8 @@ protobuf = "3.2.0"
 protobuf-json-mapping = "3.2.0"
 thousands = "0.2.0"
 rayon = "1.7"
+crate = "0.0.2"
+html-escape = "0.2.13"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/DrDotnet.Profilers/api/clr_profiler_info.rs
+++ b/src/DrDotnet.Profilers/api/clr_profiler_info.rs
@@ -240,8 +240,8 @@ impl NameResolver for ClrProfilerInfo {
                                 return arg_name;
                             }).join(", ");
 
-                            // Surrounds generic arguments with < > in html
-                            outstring.push_str(&format!("&lt;{}&gt;", arg_names));
+                            // Surrounds generic arguments with < >
+                            outstring.push_str(&format!("<{}>", arg_names));
                         },
                         Err(_) => {
                             error!("We have an error...");

--- a/src/DrDotnet.Profilers/profilers/gc_survivors_profiler.rs
+++ b/src/DrDotnet.Profilers/profilers/gc_survivors_profiler.rs
@@ -300,12 +300,13 @@ impl GCSurvivorsProfiler
     fn print_html(&self, tree: &TreeNode<ClassID, References>, report: &mut Report)
     {
         let refs = &tree.get_inclusive_value();
-        let class_name = if tree.key == 0 { "Path truncated because of depth limit reached".to_owned() } else { self.name_resolver.get_class_name(tree.key) };
+        let mut class_name = if tree.key == 0 { "Path truncated because of depth limit reached".to_owned() } else { self.name_resolver.get_class_name(tree.key) };
+        let escaped_class_name = html_escape::encode_text(&mut class_name);
 
         let has_children = tree.children.len() > 0;
 
         if has_children {
-            report.write_line(format!("<details><summary><span>{refs}</span>{class_name}</summary>"));
+            report.write_line(format!("<details><summary><span>{refs}</span>{escaped_class_name}</summary>"));
             report.write_line(format!("<ul>"));
             for child in &tree.children {
                 self.print_html(child, report);
@@ -313,7 +314,7 @@ impl GCSurvivorsProfiler
             report.write_line(format!("</ul>"));
             report.write_line(format!("</details>"));
         } else {
-            report.write_line(format!("<li><span>{refs}</span>{class_name}</li>"));
+            report.write_line(format!("<li><span>{refs}</span>{escaped_class_name}</li>"));
         }
     }
 }


### PR DESCRIPTION
This is a suggestion, it’s possible that this approach may be excessive and could impact performance (perhaps we should prioritize efficiency instead).