### PR TITLE
Reduce memory usage with making an object referencers an `Option<T>`

### DIFF
--- a/src/DrDotnet.Profilers/Cargo.toml
+++ b/src/DrDotnet.Profilers/Cargo.toml
@@ -24,6 +24,7 @@ thousands = "0.2.0"
 rayon = "1.7"
 crate = "0.0.2"
 html-escape = "0.2.13"
+deepsize = "0.2.0"
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
Add a way to estimate the size of `object_to_referencers`.   
Add measurement of time spend doing garbage collection (and so including the time taken to build `object_to_referencers`).  

### Before
- Deep size of object references: 1556208 bytes
- Garbage collection done in 4 ms

### With `Option<Vec<...>>`
- Deep size of object references: 1232256 bytes (~ -25%)
- Garbage collection done in 4 ms (unchanged)