### PR TITLE
Simple hasher

### DIFF
--- a/src/DrDotnet.Profilers/profilers/gc_survivors_profiler.rs
+++ b/src/DrDotnet.Profilers/profilers/gc_survivors_profiler.rs
@@ -208,7 +208,7 @@ impl GCSurvivorsProfiler
         // Free some memory
         self.object_to_referencers = HashMap::new();
 
-        info!("Graph built in {} ms", now.elapsed().as_millis());
+        info!("Graph built in {} ms", 0.001 * now.elapsed().as_micros() as f64);
 
         sequences
     }
@@ -227,7 +227,7 @@ impl GCSurvivorsProfiler
 
         sequences.clear();
 
-        info!("Tree built in {} ms", now.elapsed().as_millis());
+        info!("Tree built in {} ms", 0.001 * now.elapsed().as_micros() as f64);
 
         info!("Sorting tree");
 
@@ -254,7 +254,7 @@ impl GCSurvivorsProfiler
             tree.sort_by_iterative(compare);
         }
  
-        info!("Tree sorted in {} ms", now.elapsed().as_millis());
+        info!("Tree sorted in {} ms", 0.001 * now.elapsed().as_micros() as f64);
 
         return tree;
     }
@@ -277,7 +277,7 @@ impl GCSurvivorsProfiler
             self.print_html(&tree_node, &mut report);
         }
 
-        info!("Report written in {} ms", now.elapsed().as_millis());
+        info!("Report written in {} ms", 0.001 * now.elapsed().as_micros() as f64);
 
         Ok(())
     }
@@ -371,7 +371,7 @@ impl CorProfilerCallback2 for GCSurvivorsProfiler
             return Ok(());
         }
 
-        info!("Garbage collection done in {} ms", self.gc_start_time.unwrap().elapsed().as_millis());
+        info!("Garbage collection done in {} ms", 0.001 * self.gc_start_time.unwrap().elapsed().as_micros() as f64);
 
         // Disable profiling to free some resources
         match self.clr().set_event_mask(ffi::COR_PRF_MONITOR::COR_PRF_MONITOR_NONE) {
@@ -379,8 +379,7 @@ impl CorProfilerCallback2 for GCSurvivorsProfiler
             Err(hresult) => error!("Error setting event mask: {:?}", hresult)
         }
 
-        // Before Option<T> : 1555856 bytes
-        info!(">>> Deep size of object references: {} bytes", self.object_to_referencers.deep_size_of());
+        info!("Deep size of object references: {} bytes", self.object_to_referencers.deep_size_of());
 
         let mut sequences = self.build_sequences();
         let tree = self.build_tree(&mut sequences);

--- a/src/DrDotnet.Profilers/utils/mod.rs
+++ b/src/DrDotnet.Profilers/utils/mod.rs
@@ -6,3 +6,6 @@ pub use tree::*;
 
 pub mod name_resolver;
 pub use name_resolver::*;
+
+pub mod simple_hasher;
+pub use simple_hasher::*;

--- a/src/DrDotnet.Profilers/utils/simple_hasher.rs
+++ b/src/DrDotnet.Profilers/utils/simple_hasher.rs
@@ -1,0 +1,55 @@
+use std::hash::Hasher;
+        
+pub struct SimpleHasher(u64);
+
+impl Default for SimpleHasher {
+    fn default() -> SimpleHasher {
+        SimpleHasher(0)
+    }
+}
+
+impl Hasher for SimpleHasher {
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    fn write(&mut self, _bytes: &[u8]) { 
+        panic!("Not supposed to be called");
+    }
+
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        let mut hash: u64 = i as u64;
+        hash ^= hash >> 33;
+        hash = hash.wrapping_mul(0xff51afd7ed558ccd);
+        hash ^= hash >> 33;
+        hash = hash.wrapping_mul(0xc4ceb9fe1a85ec53);
+        hash ^= hash >> 33;
+        self.0 = hash;
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        let mut hash = i;
+        hash ^= hash >> 33;
+        hash = hash.wrapping_mul(0xff51afd7ed558ccd);
+        hash ^= hash >> 33;
+        hash = hash.wrapping_mul(0xc4ceb9fe1a85ec53);
+        hash ^= hash >> 33;
+        self.0 = hash;
+    }
+
+    #[inline]
+    fn write_usize(&mut self, i: usize) {
+        let mut hash = i as u64;
+        hash ^= hash >> 33;
+        hash = hash.wrapping_mul(0xff51afd7ed558ccd);
+        hash ^= hash >> 33;
+        hash = hash.wrapping_mul(0xc4ceb9fe1a85ec53);
+        hash ^= hash >> 33;
+        self.0 = hash;
+    }
+}


### PR DESCRIPTION
From Rust 2018 documentation:

> By default, HashMap uses a cryptographically secure hashing function that can provide resistance to Denial of Service (DoS) attacks. This is not the fastest hashing algorithm available, but the trade-off for better security that comes with the drop in performance is worth it.

We don't need cryptographically secure hashing here, a simple hashing method will do. That should improve performances.

### With default hashing
```
14:51:50 [INFO] Garbage collection done in 4.465 ms
14:51:50 [INFO] Graph built in 28.789 ms
14:51:50 [INFO] Tree built in 5.598 ms
14:51:50 [INFO] Tree sorted in 32.867 ms
14:51:50 [INFO] Report written in 35.818 ms
```

### With simple hashing
```
14:55:07 [INFO] Garbage collection done in 3.48 ms 🔽 ~ -25%
14:55:07 [INFO] Graph built in 17.638 ms 🔽 ~ -40%
14:55:07 [INFO] Tree built in 5.24 ms
14:55:07 [INFO] Tree sorted in 15.876 ms 🔽  ~ -50%
14:55:07 [INFO] Report written in 30.628 ms 🔽 ~ -10%
```