### PR TITLE
Build multi-arch (amd64/arm64) Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Keep the build context small and free of host build outputs:
+# the image rebuilds everything from source in the build stage.
+.git
+.github
+.serena
+.remember
+docs
+res
+tests
+bin
+obj
+target
+**/bin
+**/obj
+**/target
+pub
+pub-local
+*.user

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
-# Keep the build context small and free of host build outputs:
-# the image rebuilds everything from source in the build stage.
+# build context excludes host build outputs (the image builds from source)
 .git
 .github
 .serena

--- a/.github/actions/push-docker/action.yml
+++ b/.github/actions/push-docker/action.yml
@@ -35,27 +35,65 @@ runs:
         BUILD_NUMBER: ${{ github.run_number }}
       run: dotnet publish src/DrDotnet.Web/DrDotnet.Web.csproj -c Release -o pub
 
-    - name: Copy Native Profilers
+    # The publish step above already built the native profiler for the host
+    # architecture (linux-x64) via the csproj pre-build cargo step.
+    # We additionally cross-compile it for linux-arm64 so the Docker image can be
+    # multi-arch. Building on the same runner keeps the glibc floor identical to
+    # the x64 build (gcc-aarch64-linux-gnu on ubuntu-20.04 targets glibc 2.31).
+    - name: Build ARM64 Native Profiler
       shell: bash
-      run: cp bin/release/libprofilers.so pub/
+      env:
+        VERSION: ${{ inputs.version }}
+        BUILD_NUMBER: ${{ github.run_number }}
+        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+      run: |
+        set -euo pipefail
+        rustup target add aarch64-unknown-linux-gnu
+        sudo apt-get update
+        sudo apt-get install -y gcc-aarch64-linux-gnu
+        (cd src/DrDotnet.Profilers && cargo build --release --target aarch64-unknown-linux-gnu)
+
+    # Stage one native library per architecture at the build-context root.
+    # The Dockerfile picks the right one using buildx's TARGETARCH build arg.
+    - name: Stage Native Profilers
+      shell: bash
+      run: |
+        set -euo pipefail
+        cp bin/release/libprofilers.so libprofilers-amd64.so
+        arm_so="$(find bin -path '*aarch64-unknown-linux-gnu/release/libprofilers.so' | head -n1)"
+        cp "$arm_so" libprofilers-arm64.so
+        ls -l libprofilers-amd64.so libprofilers-arm64.so
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Docker Login
       shell: bash
       run: echo ${{ inputs.docker-token }} | docker login -u ${{ inputs.docker-username }} --password-stdin
 
-    - name: Docker Build (with suffix)
+    - name: Docker Build & Push (with suffix)
       if: ${{ inputs.suffix != '' }}
       shell: bash
-      run: docker build -f src/Dockerfile -t drdotnet/web:${{ inputs.version }}.${{ github.run_number }}-${{ inputs.suffix }} .
+      run: |
+        docker buildx build \
+          --platform linux/amd64,linux/arm64 \
+          -f src/Dockerfile \
+          -t drdotnet/web:${{ inputs.version }}.${{ github.run_number }}-${{ inputs.suffix }} \
+          --push .
 
-    - name: Docker Build
+    - name: Docker Build & Push
       if: ${{ inputs.suffix == '' }}
       env:
         VERSION: ${{ inputs.version }}
       shell: bash
-      run: docker build --build-arg="HIDE_UNRELEASED=1" -f src/Dockerfile -t drdotnet/web:latest -t drdotnet/web:${VERSION%.*} .
-
-    - name: Docker Push
-      shell: bash
-      run: docker push --all-tags drdotnet/web
-      
+      run: |
+        docker buildx build \
+          --platform linux/amd64,linux/arm64 \
+          --build-arg="HIDE_UNRELEASED=1" \
+          -f src/Dockerfile \
+          -t drdotnet/web:latest \
+          -t drdotnet/web:${VERSION%.*} \
+          --push .

--- a/.github/actions/push-docker/action.yml
+++ b/.github/actions/push-docker/action.yml
@@ -35,23 +35,16 @@ runs:
         BUILD_NUMBER: ${{ github.run_number }}
       run: dotnet publish src/DrDotnet.Web/DrDotnet.Web.csproj -c Release -o pub
 
-    # The publish step above already built the native profiler for the host
+    # The publish step above already built the native profiler for this runner's
     # architecture (linux-x64) via the csproj pre-build cargo step.
-    # We additionally cross-compile it for linux-arm64 so the Docker image can be
-    # multi-arch. Building on the same runner keeps the glibc floor identical to
-    # the x64 build (gcc-aarch64-linux-gnu on ubuntu-20.04 targets glibc 2.31).
-    - name: Build ARM64 Native Profiler
-      shell: bash
-      env:
-        VERSION: ${{ inputs.version }}
-        BUILD_NUMBER: ${{ github.run_number }}
-        CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-      run: |
-        set -euo pipefail
-        rustup target add aarch64-unknown-linux-gnu
-        sudo apt-get update
-        sudo apt-get install -y gcc-aarch64-linux-gnu
-        (cd src/DrDotnet.Profilers && cargo build --release --target aarch64-unknown-linux-gnu)
+    # The linux-arm64 library is built natively on an ARM runner in the
+    # `build-arm64-profiler` job (no cross-compilation, no QEMU) and consumed
+    # here as an artifact.
+    - name: Download ARM64 Native Profiler
+      uses: actions/download-artifact@v4
+      with:
+        name: libprofilers-arm64
+        path: arm64-profiler
 
     # Stage one native library per architecture at the build-context root.
     # The Dockerfile picks the right one using buildx's TARGETARCH build arg.
@@ -60,13 +53,12 @@ runs:
       run: |
         set -euo pipefail
         cp bin/release/libprofilers.so libprofilers-amd64.so
-        arm_so="$(find bin -path '*aarch64-unknown-linux-gnu/release/libprofilers.so' | head -n1)"
-        cp "$arm_so" libprofilers-arm64.so
+        cp arm64-profiler/libprofilers.so libprofilers-arm64.so
         ls -l libprofilers-amd64.so libprofilers-arm64.so
+        file libprofilers-amd64.so libprofilers-arm64.so 2>/dev/null || true
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
+    # buildx assembles the multi-arch manifest. No QEMU is needed because the
+    # Dockerfile only COPYs files (no RUN), so nothing is executed under emulation.
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 

--- a/.github/actions/push-docker/action.yml
+++ b/.github/actions/push-docker/action.yml
@@ -1,12 +1,10 @@
-name: 'Push Docker'
+name: 'Build and push (single arch, by digest)'
+description: 'Builds the multi-stage Dockerfile natively for the current runner architecture and pushes it by digest.'
 
 inputs:
   version:
-    description: 'The version (x.x.x)'
+    description: 'The version (x.x.x), passed as a build-arg to stamp the build'
     required: true
-  suffix:
-    description: 'The docker image suffix'
-    required: false
   docker-token:
     description: 'Docker deploy token'
     required: true
@@ -14,78 +12,34 @@ inputs:
     description: 'Docker username'
     required: true
 
+outputs:
+  digest:
+    description: 'Digest of the single-arch image pushed by this runner'
+    value: ${{ steps.build.outputs.digest }}
+
 runs:
   using: "composite"
 
   steps:
-    - name: Install Rust Toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-
-    - name: Install Dotnet SDK
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '8.0'
-
-    - name: Publish
-      shell: bash
-      env:
-        VERSION: ${{ inputs.version }}
-        BUILD_NUMBER: ${{ github.run_number }}
-      run: dotnet publish src/DrDotnet.Web/DrDotnet.Web.csproj -c Release -o pub
-
-    # The publish step above already built the native profiler for this runner's
-    # architecture (linux-x64) via the csproj pre-build cargo step.
-    # The linux-arm64 library is built natively on an ARM runner in the
-    # `build-arm64-profiler` job (no cross-compilation, no QEMU) and consumed
-    # here as an artifact.
-    - name: Download ARM64 Native Profiler
-      uses: actions/download-artifact@v4
-      with:
-        name: libprofilers-arm64
-        path: arm64-profiler
-
-    # Stage one native library per architecture at the build-context root.
-    # The Dockerfile picks the right one using buildx's TARGETARCH build arg.
-    - name: Stage Native Profilers
-      shell: bash
-      run: |
-        set -euo pipefail
-        cp bin/release/libprofilers.so libprofilers-amd64.so
-        cp arm64-profiler/libprofilers.so libprofilers-arm64.so
-        ls -l libprofilers-amd64.so libprofilers-arm64.so
-        file libprofilers-amd64.so libprofilers-arm64.so 2>/dev/null || true
-
-    # buildx assembles the multi-arch manifest. No QEMU is needed because the
-    # Dockerfile only COPYs files (no RUN), so nothing is executed under emulation.
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
     - name: Docker Login
-      shell: bash
-      run: echo ${{ inputs.docker-token }} | docker login -u ${{ inputs.docker-username }} --password-stdin
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.docker-username }}
+        password: ${{ inputs.docker-token }}
 
-    - name: Docker Build & Push (with suffix)
-      if: ${{ inputs.suffix != '' }}
-      shell: bash
-      run: |
-        docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          -f src/Dockerfile \
-          -t drdotnet/web:${{ inputs.version }}.${{ github.run_number }}-${{ inputs.suffix }} \
-          --push .
-
-    - name: Docker Build & Push
-      if: ${{ inputs.suffix == '' }}
-      env:
-        VERSION: ${{ inputs.version }}
-      shell: bash
-      run: |
-        docker buildx build \
-          --platform linux/amd64,linux/arm64 \
-          --build-arg="HIDE_UNRELEASED=1" \
-          -f src/Dockerfile \
-          -t drdotnet/web:latest \
-          -t drdotnet/web:${VERSION%.*} \
-          --push .
+    # Built natively for the runner's architecture (no --platform, no QEMU): the
+    # multi-stage Dockerfile compiles the managed app + native profiler in-image.
+    # Pushed by digest (untagged); the merge job tags the assembled manifest list.
+    - name: Build and push by digest
+      id: build
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: src/Dockerfile
+        outputs: type=image,name=drdotnet/web,push-by-digest=true,name-canonical=true,push=true
+        build-args: |
+          VERSION=${{ inputs.version }}
+          BUILD_NUMBER=${{ github.run_number }}

--- a/.github/actions/push-docker/action.yml
+++ b/.github/actions/push-docker/action.yml
@@ -1,10 +1,13 @@
-name: 'Build and push (single arch, by digest)'
-description: 'Builds the multi-stage Dockerfile natively for the current runner architecture and pushes it by digest.'
+name: 'Push Docker'
+description: 'Builds and pushes the multi-arch (amd64/arm64) web image.'
 
 inputs:
   version:
-    description: 'The version (x.x.x), passed as a build-arg to stamp the build'
+    description: 'The version (x.x.x)'
     required: true
+  suffix:
+    description: 'The docker image suffix'
+    required: false
   docker-token:
     description: 'Docker deploy token'
     required: true
@@ -12,15 +15,13 @@ inputs:
     description: 'Docker username'
     required: true
 
-outputs:
-  digest:
-    description: 'Digest of the single-arch image pushed by this runner'
-    value: ${{ steps.build.outputs.digest }}
-
 runs:
   using: "composite"
 
   steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
@@ -30,16 +31,25 @@ runs:
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.docker-token }}
 
-    # Built natively for the runner's architecture (no --platform, no QEMU): the
-    # multi-stage Dockerfile compiles the managed app + native profiler in-image.
-    # Pushed by digest (untagged); the merge job tags the assembled manifest list.
-    - name: Build and push by digest
-      id: build
+    - name: Compute tags
+      id: tags
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.suffix }}" ]; then
+          echo "tags=drdotnet/web:${{ inputs.version }}.${{ github.run_number }}-${{ inputs.suffix }}" >> "$GITHUB_OUTPUT"
+        else
+          v="${{ inputs.version }}"
+          echo "tags=drdotnet/web:latest,drdotnet/web:${v%.*}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Build and push
       uses: docker/build-push-action@v6
       with:
         context: .
         file: src/Dockerfile
-        outputs: type=image,name=drdotnet/web,push-by-digest=true,name-canonical=true,push=true
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.tags.outputs.tags }}
         build-args: |
           VERSION=${{ inputs.version }}
           BUILD_NUMBER=${{ github.run_number }}

--- a/.github/actions/push-docker/action.yml
+++ b/.github/actions/push-docker/action.yml
@@ -19,9 +19,6 @@ runs:
   using: "composite"
 
   steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout 
+      - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install Rust Toolchain
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: '8.0'
-          
+
       - name: Install Dependencies
         run: dotnet restore
 
@@ -34,50 +34,81 @@ jobs:
       - name: Test
         run: dotnet test --no-restore --verbosity normal
 
-  build-arm64-profiler:
+  # One native build per architecture (no QEMU): each runner builds the multi-stage
+  # Dockerfile for its own arch and pushes the single-arch image by digest.
+  build:
     if: github.ref != 'refs/heads/master'
-    name: Build ARM64 Native Profiler
+    name: Build (${{ matrix.platform }})
     needs: [build-test]
-    runs-on: ubuntu-22.04-arm # Native ARM runner: builds libprofilers.so for aarch64
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
-      - name: Build Native Profiler (linux-arm64)
-        shell: bash
-        env:
-          VERSION: '0.0.0'
-          BUILD_NUMBER: ${{ github.run_number }}
-        run: (cd src/DrDotnet.Profilers && cargo build --release)
-
-      - name: Upload Native Profiler
-        uses: actions/upload-artifact@v4
-        with:
-          name: libprofilers-arm64
-          path: bin/release/libprofilers.so
-          if-no-files-found: error
-
-  push-docker:
-    if: github.ref != 'refs/heads/master'
-    name: Push Test Docker Image
-    needs: [build-test, build-arm64-profiler]
     environment: dev
-    runs-on: ubuntu-22.04 # ubuntu-20.04 runners were retired; 22.04 (glibc 2.35) matches the arm64 builder and stays <= .NET 8's Debian 12 base (glibc 2.36)
-        
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: amd64
+            runner: ubuntu-latest
+          - platform: arm64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Create Docker Image
+      - name: Build & push by digest
+        id: build
         uses: ./.github/actions/push-docker
         with:
           version: '0.0.0' # A test docker image has no version
-          suffix: ${{ github.ref_name }} # A test docker image can be identified by the branch name
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p digests
+          echo "${{ steps.build.outputs.digest }}" > "digests/${{ matrix.platform }}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.platform }}
+          path: digests/${{ matrix.platform }}
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-arch digests into one multi-arch manifest list and tag it.
+  merge:
+    if: github.ref != 'refs/heads/master'
+    name: Push Test Docker Image
+    needs: [build]
+    environment: dev
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list
+        shell: bash
+        run: |
+          set -euo pipefail
+          # A test docker image is identified by the branch name
+          TAG="drdotnet/web:0.0.0.${{ github.run_number }}-${{ github.ref_name }}"
+          refs=""
+          for f in digests/*; do refs="$refs drdotnet/web@$(cat "$f")"; done
+          docker buildx imagetools create -t "$TAG" $refs
+          docker buildx imagetools inspect "$TAG"

--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build & push
         uses: ./.github/actions/push-docker
         with:
-          version: '0.0.0'
-          suffix: ${{ github.ref_name }}
+          version: '0.0.0' # A test docker image has no version
+          suffix: ${{ github.ref_name }} # A test docker image can be identified by the branch name
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -34,81 +34,21 @@ jobs:
       - name: Test
         run: dotnet test --no-restore --verbosity normal
 
-  # One native build per architecture (no QEMU): each runner builds the multi-stage
-  # Dockerfile for its own arch and pushes the single-arch image by digest.
-  build:
+  push-docker:
     if: github.ref != 'refs/heads/master'
-    name: Build (${{ matrix.platform }})
+    name: Push Test Docker Image
     needs: [build-test]
     environment: dev
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: amd64
-            runner: ubuntu-latest
-          - platform: arm64
-            runner: ubuntu-22.04-arm
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Build & push by digest
-        id: build
+      - name: Build & push
         uses: ./.github/actions/push-docker
         with:
-          version: '0.0.0' # A test docker image has no version
+          version: '0.0.0'
+          suffix: ${{ github.ref_name }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
-
-      - name: Export digest
-        shell: bash
-        run: |
-          mkdir -p digests
-          echo "${{ steps.build.outputs.digest }}" > "digests/${{ matrix.platform }}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digest-${{ matrix.platform }}
-          path: digests/${{ matrix.platform }}
-          if-no-files-found: error
-          retention-days: 1
-
-  # Assemble the per-arch digests into one multi-arch manifest list and tag it.
-  merge:
-    if: github.ref != 'refs/heads/master'
-    name: Push Test Docker Image
-    needs: [build]
-    environment: dev
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: digests
-          pattern: digest-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker Login
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Create manifest list
-        shell: bash
-        run: |
-          set -euo pipefail
-          # A test docker image is identified by the branch name
-          TAG="drdotnet/web:0.0.0.${{ github.run_number }}-${{ github.ref_name }}"
-          refs=""
-          for f in digests/*; do refs="$refs drdotnet/web@$(cat "$f")"; done
-          docker buildx imagetools create -t "$TAG" $refs
-          docker buildx imagetools inspect "$TAG"

--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -34,10 +34,39 @@ jobs:
       - name: Test
         run: dotnet test --no-restore --verbosity normal
 
+  build-arm64-profiler:
+    if: github.ref != 'refs/heads/master'
+    name: Build ARM64 Native Profiler
+    needs: [build-test]
+    runs-on: ubuntu-22.04-arm # Native ARM runner: builds libprofilers.so for aarch64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Build Native Profiler (linux-arm64)
+        shell: bash
+        env:
+          VERSION: '0.0.0'
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: (cd src/DrDotnet.Profilers && cargo build --release)
+
+      - name: Upload Native Profiler
+        uses: actions/upload-artifact@v4
+        with:
+          name: libprofilers-arm64
+          path: bin/release/libprofilers.so
+          if-no-files-found: error
+
   push-docker:
     if: github.ref != 'refs/heads/master'
     name: Push Test Docker Image
-    needs: [build-test]
+    needs: [build-test, build-arm64-profiler]
     environment: dev
     runs-on: ubuntu-20.04 # Had some GLIBC 2.33 errors not found since github switched to 22.04 end of 2022
         

--- a/.github/workflows/on-commit.yml
+++ b/.github/workflows/on-commit.yml
@@ -68,7 +68,7 @@ jobs:
     name: Push Test Docker Image
     needs: [build-test, build-arm64-profiler]
     environment: dev
-    runs-on: ubuntu-20.04 # Had some GLIBC 2.33 errors not found since github switched to 22.04 end of 2022
+    runs-on: ubuntu-22.04 # ubuntu-20.04 runners were retired; 22.04 (glibc 2.35) matches the arm64 builder and stays <= .NET 8's Debian 12 base (glibc 2.36)
         
     steps:
       - name: Checkout

--- a/.github/workflows/on-version-tag.yml
+++ b/.github/workflows/on-version-tag.yml
@@ -45,7 +45,7 @@ jobs:
   push-docker:
     name: Push Docker
     needs: [check, build-arm64-profiler]
-    runs-on: ubuntu-20.04 # Had some GLIBC 2.33 errors not found since github switched to 22.04 end of 2022
+    runs-on: ubuntu-22.04 # ubuntu-20.04 runners were retired; 22.04 (glibc 2.35) matches the arm64 builder and stays <= .NET 8's Debian 12 base (glibc 2.36)
         
     steps:
       - name: Checkout

--- a/.github/workflows/on-version-tag.yml
+++ b/.github/workflows/on-version-tag.yml
@@ -14,9 +14,37 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+  build-arm64-profiler:
+    name: Build ARM64 Native Profiler
+    needs: [check]
+    runs-on: ubuntu-22.04-arm # Native ARM runner: builds libprofilers.so for aarch64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Build Native Profiler (linux-arm64)
+        shell: bash
+        env:
+          VERSION: ${{ github.ref_name }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: (cd src/DrDotnet.Profilers && cargo build --release)
+
+      - name: Upload Native Profiler
+        uses: actions/upload-artifact@v4
+        with:
+          name: libprofilers-arm64
+          path: bin/release/libprofilers.so
+          if-no-files-found: error
+
   push-docker:
     name: Push Docker
-    needs: [check]
+    needs: [check, build-arm64-profiler]
     runs-on: ubuntu-20.04 # Had some GLIBC 2.33 errors not found since github switched to 22.04 end of 2022
         
     steps:

--- a/.github/workflows/on-version-tag.yml
+++ b/.github/workflows/on-version-tag.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build & push
         uses: ./.github/actions/push-docker
         with:
-          version: ${{ github.ref_name }}
+          version: ${{ github.ref_name }} # Since this job is triggered from x.x.x tag, we can use the tag as version
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
 

--- a/.github/workflows/on-version-tag.yml
+++ b/.github/workflows/on-version-tag.yml
@@ -14,49 +14,83 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-  build-arm64-profiler:
-    name: Build ARM64 Native Profiler
+  # One native build per architecture (no QEMU): each runner builds the multi-stage
+  # Dockerfile for its own arch and pushes the single-arch image by digest.
+  build:
+    name: Build (${{ matrix.platform }})
     needs: [check]
-    runs-on: ubuntu-22.04-arm # Native ARM runner: builds libprofilers.so for aarch64
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: amd64
+            runner: ubuntu-latest
+          - platform: arm64
+            runner: ubuntu-22.04-arm
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Build & push by digest
+        id: build
+        uses: ./.github/actions/push-docker
         with:
-          toolchain: stable
+          version: ${{ github.ref_name }} # Triggered from x.x.x tag, use it as version
+          docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
 
-      - name: Build Native Profiler (linux-arm64)
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p digests
+          echo "${{ steps.build.outputs.digest }}" > "digests/${{ matrix.platform }}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.platform }}
+          path: digests/${{ matrix.platform }}
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble the per-arch digests into one multi-arch manifest list and tag it.
+  merge:
+    name: Push Docker
+    needs: [build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create manifest list
         shell: bash
         env:
           VERSION: ${{ github.ref_name }}
-          BUILD_NUMBER: ${{ github.run_number }}
-        run: (cd src/DrDotnet.Profilers && cargo build --release)
-
-      - name: Upload Native Profiler
-        uses: actions/upload-artifact@v4
-        with:
-          name: libprofilers-arm64
-          path: bin/release/libprofilers.so
-          if-no-files-found: error
-
-  push-docker:
-    name: Push Docker
-    needs: [check, build-arm64-profiler]
-    runs-on: ubuntu-22.04 # ubuntu-20.04 runners were retired; 22.04 (glibc 2.35) matches the arm64 builder and stays <= .NET 8's Debian 12 base (glibc 2.36)
-        
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Create Docker Image
-        uses: ./.github/actions/push-docker
-        with:
-          version: ${{ github.ref_name }} # Since this job is triggered from x.x.x tag, we can use the tag as version
-          docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
-          docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
+        run: |
+          set -euo pipefail
+          refs=""
+          for f in digests/*; do refs="$refs drdotnet/web@$(cat "$f")"; done
+          docker buildx imagetools create \
+            -t drdotnet/web:latest \
+            -t "drdotnet/web:${VERSION%.*}" \
+            $refs
+          docker buildx imagetools inspect drdotnet/web:latest
 
   create-release:
     name: Create Release

--- a/.github/workflows/on-version-tag.yml
+++ b/.github/workflows/on-version-tag.yml
@@ -14,83 +14,21 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-  # One native build per architecture (no QEMU): each runner builds the multi-stage
-  # Dockerfile for its own arch and pushes the single-arch image by digest.
-  build:
-    name: Build (${{ matrix.platform }})
+  push-docker:
+    name: Push Docker
     needs: [check]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - platform: amd64
-            runner: ubuntu-latest
-          - platform: arm64
-            runner: ubuntu-22.04-arm
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Build & push by digest
-        id: build
+      - name: Build & push
         uses: ./.github/actions/push-docker
         with:
-          version: ${{ github.ref_name }} # Triggered from x.x.x tag, use it as version
+          version: ${{ github.ref_name }}
           docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
           docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
-
-      - name: Export digest
-        shell: bash
-        run: |
-          mkdir -p digests
-          echo "${{ steps.build.outputs.digest }}" > "digests/${{ matrix.platform }}"
-
-      - name: Upload digest
-        uses: actions/upload-artifact@v4
-        with:
-          name: digest-${{ matrix.platform }}
-          path: digests/${{ matrix.platform }}
-          if-no-files-found: error
-          retention-days: 1
-
-  # Assemble the per-arch digests into one multi-arch manifest list and tag it.
-  merge:
-    name: Push Docker
-    needs: [build]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download digests
-        uses: actions/download-artifact@v4
-        with:
-          path: digests
-          pattern: digest-*
-          merge-multiple: true
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker Login
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Create manifest list
-        shell: bash
-        env:
-          VERSION: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          refs=""
-          for f in digests/*; do refs="$refs drdotnet/web@$(cat "$f")"; done
-          docker buildx imagetools create \
-            -t drdotnet/web:latest \
-            -t "drdotnet/web:${VERSION%.*}" \
-            $refs
-          docker buildx imagetools inspect drdotnet/web:latest
 
   create-release:
     name: Create Release

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,5 +1,11 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
+# TARGETARCH is provided automatically by `docker buildx` (e.g. "amd64", "arm64").
+# The native profiler library is architecture-specific: the CLR loads it in-process
+# into the profiled application, so its CPU architecture MUST match the image's.
+# Each architecture's library is built outside the image and selected here.
+ARG TARGETARCH
 COPY pub app/
+COPY libprofilers-${TARGETARCH}.so app/libprofilers.so
 WORKDIR /app
 # Disable diagnostics for dr-dotnet, to disambiguate it from profileable processes
 ENV DOTNET_EnableDiagnostics=0

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,31 +1,21 @@
-# ---- Build stage: builds the managed app AND the native Rust profiler in-image ----
-# Built once per target platform by `docker buildx`; the native profiler therefore
-# always matches the image architecture (the CLR loads it in-process).
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-
-# Rust toolchain: the DrDotnet.csproj pre-build step compiles libprofilers.so with cargo.
+# Rust toolchain for the native profiler build
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates build-essential \
     && rm -rf /var/lib/apt/lists/* \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
 ENV PATH="/root/.cargo/bin:${PATH}"
-
 WORKDIR /src
 COPY . .
-
 ARG VERSION=0.0.0
 ARG BUILD_NUMBER=0
 ENV VERSION=${VERSION} BUILD_NUMBER=${BUILD_NUMBER}
-
-# `dotnet publish` builds the portable managed app and triggers the cargo build of
-# the native profiler (csproj pre-build) into bin/release/libprofilers.so.
 RUN dotnet publish src/DrDotnet.Web/DrDotnet.Web.csproj -c Release -o /app \
     && cp bin/release/libprofilers.so /app/libprofilers.so
 
-# ---- Runtime stage ----
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
 COPY --from=build /app /app/
 WORKDIR /app
-# Disable diagnostics for dr-dotnet, to disambiguate it from profileable processes
+# Disable diagnostics so dr-dotnet itself isn't profileable
 ENV DOTNET_EnableDiagnostics=0
 ENTRYPOINT ["dotnet", "DrDotnet.Web.dll"]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,11 +1,30 @@
+# ---- Build stage: builds the managed app AND the native Rust profiler in-image ----
+# Built once per target platform by `docker buildx`; the native profiler therefore
+# always matches the image architecture (the CLR loads it in-process).
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+# Rust toolchain: the DrDotnet.csproj pre-build step compiles libprofilers.so with cargo.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates build-essential \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /src
+COPY . .
+
+ARG VERSION=0.0.0
+ARG BUILD_NUMBER=0
+ENV VERSION=${VERSION} BUILD_NUMBER=${BUILD_NUMBER}
+
+# `dotnet publish` builds the portable managed app and triggers the cargo build of
+# the native profiler (csproj pre-build) into bin/release/libprofilers.so.
+RUN dotnet publish src/DrDotnet.Web/DrDotnet.Web.csproj -c Release -o /app \
+    && cp bin/release/libprofilers.so /app/libprofilers.so
+
+# ---- Runtime stage ----
 FROM mcr.microsoft.com/dotnet/aspnet:8.0
-# TARGETARCH is provided automatically by `docker buildx` (e.g. "amd64", "arm64").
-# The native profiler library is architecture-specific: the CLR loads it in-process
-# into the profiled application, so its CPU architecture MUST match the image's.
-# Each architecture's library is built outside the image and selected here.
-ARG TARGETARCH
-COPY pub app/
-COPY libprofilers-${TARGETARCH}.so app/libprofilers.so
+COPY --from=build /app /app/
 WORKDIR /app
 # Disable diagnostics for dr-dotnet, to disambiguate it from profileable processes
 ENV DOTNET_EnableDiagnostics=0


### PR DESCRIPTION
The web image was linux/amd64 only: the native Rust profiler (libprofilers.so) was built solely for x64 and the image was produced with a plain `docker build`, so it could not run on ARM nodes.

- Dockerfile now selects the native profiler per architecture via buildx's TARGETARCH build arg (libprofilers-amd64.so / libprofilers-arm64.so).
- The push-docker action cross-compiles libprofilers.so for aarch64 (gcc-aarch64-linux-gnu, keeping the same glibc floor as the x64 build) and builds/pushes a linux/amd64,linux/arm64 manifest with `docker buildx`.

The managed .NET output is published portable, so only the native profiler library is architecture-specific.